### PR TITLE
Patch logger for ISO8601 TZ offsets and Docker build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN apk add --no-cache curl
 
 # COPY package.json package-lock.json ./
 COPY package*.json ./
-#RUN npm ci --omit=dev && npm cache clean --force
+
+# 'npm ci --omit=dev' with 'npm install --omit=dev' to fix Alpine build failure
+# RUN npm ci --omit=dev && npm cache clean --force
 RUN npm install --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/.next/standalone ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk add --no-cache curl
 
 # COPY package.json package-lock.json ./
 COPY package*.json ./
-RUN npm ci --omit=dev && npm cache clean --force
+#RUN npm ci --omit=dev && npm cache clean --force
+RUN npm install --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -6,6 +6,7 @@ import { APP_PATH } from "./lib/consts";
 import telemetryClient from "./lib/telemetry";
 
 // helper to get ISO8601 string in the TZ from process.env.TZ
+// This replaces the default Z (UTC) with the local offset from process.env.TZ
 const isoLocal = () => {
     const tz = process.env.TZ || "UTC";
     const d = new Date();
@@ -15,6 +16,8 @@ const isoLocal = () => {
     const pad = (n: number) => String(n).padStart(2, "0");
     const hours = pad(Math.floor(Math.abs(tzOffsetMin) / 60));
     const mins = pad(Math.abs(tzOffsetMin) % 60);
+
+    // Replace Z in ISO string with local offset
     return s.replace(" ", "T") + `${sign}${hours}:${mins}`;
 };
 
@@ -74,6 +77,8 @@ const logger = winston.createLogger({
         winston.format.errors({ stack: true }),
         winston.format.colorize(),
         winston.format.splat(),
+
+        // Use isoLocal so timestamps respect TZ env, not just UTC
         winston.format.timestamp({ format: isoLocal }),
         hformat
     ),

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -5,6 +5,19 @@ import path from "path";
 import { APP_PATH } from "./lib/consts";
 import telemetryClient from "./lib/telemetry";
 
+// helper to get ISO8601 string in the TZ from process.env.TZ
+const isoLocal = () => {
+    const tz = process.env.TZ || "UTC";
+    const d = new Date();
+    const s = d.toLocaleString("sv-SE", { timeZone: tz, hour12: false });
+    const tzOffsetMin = d.getTimezoneOffset();
+    const sign = tzOffsetMin <= 0 ? "+" : "-";
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const hours = pad(Math.floor(Math.abs(tzOffsetMin) / 60));
+    const mins = pad(Math.abs(tzOffsetMin) % 60);
+    return s.replace(" ", "T") + `${sign}${hours}:${mins}`;
+};
+
 const hformat = winston.format.printf(
     ({ level, label, message, timestamp, stack, ...metadata }) => {
         let msg = `${timestamp} [${level}]${label ? `[${label}]` : ""}: ${message}`;
@@ -29,7 +42,12 @@ if (config.getRawConfig().app.save_logs) {
             maxSize: "20m",
             maxFiles: "7d",
             createSymlink: true,
-            symlinkName: "pangolin.log"
+            symlinkName: "pangolin.log",
+            format: winston.format.combine(
+                winston.format.timestamp({ format: isoLocal }),
+                winston.format.splat(),
+                hformat
+            )
         })
     );
     transports.push(
@@ -42,7 +60,7 @@ if (config.getRawConfig().app.save_logs) {
             createSymlink: true,
             symlinkName: ".machinelogs.json",
             format: winston.format.combine(
-                winston.format.timestamp(),
+                winston.format.timestamp({ format: isoLocal }),
                 winston.format.splat(),
                 winston.format.json()
             )
@@ -56,7 +74,7 @@ const logger = winston.createLogger({
         winston.format.errors({ stack: true }),
         winston.format.colorize(),
         winston.format.splat(),
-        winston.format.timestamp(),
+        winston.format.timestamp({ format: isoLocal }),
         hformat
     ),
     transports


### PR DESCRIPTION
Patch logger for ISO8601 timestamps with local TZ offset and fix Docker build failure on Alpine.

References discussion: https://github.com/orgs/fosrl/discussions/1025

Note: timestamps default to +00:00 (UTC) unless TZ env is set

Optional future improvement: include tzdata in container for shell/date consistency.